### PR TITLE
feat: Add GitHub Actions workflow for Supabase deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,31 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - name: Replace Supabase credentials
+        run: |
+          sed -i "s|TU_SUPABASE_URL|${{ secrets.SUPABASE_URL }}|g" config.js
+          sed -i "s|TU_SUPABASE_KEY|${{ secrets.SUPABASE_ANON_KEY }}|g" config.js
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: .
+          # Optional: specify a different branch to deploy to
+          # publish_branch: gh-pages

--- a/config.js
+++ b/config.js
@@ -1,0 +1,18 @@
+// config.js
+const Config = {
+  supabaseUrl: 'TU_SUPABASE_URL', // Reemplazado por GitHub Actions
+  supabaseKey: 'TU_SUPABASE_KEY', // Reemplazado por GitHub Actions
+
+  getSupabaseConfig: function() {
+    const url = this.supabaseUrl;
+    const key = this.supabaseKey;
+
+    if (url === 'TU_SUPABASE_URL' || key === 'TU_SUPABASE_KEY') {
+      console.warn('Advertencia: Las credenciales de Supabase no han sido reemplazadas. Usando valores predeterminados.');
+    }
+
+    return { url, key };
+  }
+};
+
+export default Config;


### PR DESCRIPTION
This change introduces a GitHub Actions workflow to automate the deployment of the application to GitHub Pages.

A `config.js` file with placeholder credentials has been added. The workflow replaces these placeholders with `SUPABASE_URL` and `SUPABASE_ANON_KEY` from the repository secrets during the deployment process.

This ensures that the Supabase credentials are not hardcoded in the repository and are securely injected during deployment.