### PR TITLE
Feature: Implement Multiple Turns in Attention

### DIFF
--- a/turno.html
+++ b/turno.html
@@ -291,6 +291,19 @@
         </div>
       </div>
 
+      <!-- Turnos en Atencion -->
+      <div class="bg-white dark:bg-gray-800 p-6 rounded-xl shadow-md mb-6">
+        <h2 class="text-xl font-semibold text-gray-700 dark:text-gray-300 flex items-center mb-4">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 mr-2 text-green-600 dark:text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            Turnos en Atención
+        </h2>
+        <div id="listaAtencion" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+            <!-- Los turnos en atención se agregarán aquí dinámicamente -->
+        </div>
+      </div>
+
       <!-- Lista de turnos en espera -->
       <div class="bg-white dark:bg-gray-800 p-6 rounded-xl shadow-md mb-6">
         <div class="flex justify-between items-center mb-4">


### PR DESCRIPTION
- Modifies the UI in `turno.html` to include a new container for displaying multiple turns that are currently 'En atención'.
- Updates the logic in `admin/turno.js` to fetch and render all turns in the 'En atención' state.
- The main 'Turno Actual' display now shows the details of the most recent turn to be moved to the attention state, as per user requirements.
- Refactors the `turnoActual` variable to distinguish between the turn for display and the next turn in the queue for actions, maintaining the functionality of the control buttons.