### PR TITLE
feat: Mark turn as canceled instead of deleting

### DIFF
--- a/usuario/usuario.js
+++ b/usuario/usuario.js
@@ -413,7 +413,7 @@ async function mostrarMensajeConfirmacion(turnoData) {
 
       const { error } = await supabase
         .from('turnos')
-        .delete()
+        .update({ estado: 'Cancelado' })
         .eq('turno', turnoData.turno)
         .eq('negocio_id', negocioId)
         .eq('telefono', telefonoUsuario);


### PR DESCRIPTION
### **User description**
Modified the user-side cancellation logic to update the turn's status to 'Cancelado' instead of deleting the record from the database.

This change aligns the cancellation behavior with the admin panel's design, which is capable of displaying different turn statuses. Now, when a user cancels a turn, it will be preserved in the system and appear as 'Cancelado' in the admin's turn history, providing better tracking and data integrity.


___

### **PR Type**
Enhancement


___

### **Description**
- Changed turn cancellation from deletion to status update

- Preserves canceled turns in database for better tracking

- Aligns user cancellation with admin panel design

- Improves data integrity and audit trail


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User clicks cancel"] --> B["Confirmation dialog"]
  B --> C["Update turn status to 'Cancelado'"]
  C --> D["Turn preserved in database"]
  D --> E["Admin can view canceled turns"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>usuario.js</strong><dd><code>Update cancellation logic to mark status</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

usuario/usuario.js

<ul><li>Replaced <code>.delete()</code> with <code>.update({ estado: 'Cancelado' })</code><br> <li> Modified turn cancellation logic to preserve records<br> <li> Maintains same filtering conditions for the operation</ul>


</details>


  </td>
  <td><a href="https://github.com/Empredndedor/turnord-oficial/pull/19/files#diff-6e0f8fd3a60b9ee403de08a6a962129f7dabf540649279c3fdf50fb2528f71e4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

