### PR TITLE
Se integra un sistema de notificaciones de navegador para mejorar la …

### DIFF
--- a/usuario/usuario.js
+++ b/usuario/usuario.js
@@ -582,6 +582,13 @@ async function tomarTurnoSimple(nombre, telefono, servicio) {
 
   turnoAsignado = nuevoTurno;
   await mostrarMensajeConfirmacion({ nombre, turno: nuevoTurno });
+
+  // Enviar notificación de confirmación
+  enviarNotificacion(
+    `¡Turno ${nuevoTurno} confirmado!`,
+    `Hola ${nombre}, hemos registrado tu turno. Te notificaremos cuando se acerque tu momento.`
+  );
+
   const form = document.getElementById('formRegistroNegocio');
   if (form) form.reset();
   cerrarModal();
@@ -590,6 +597,26 @@ async function tomarTurnoSimple(nombre, telefono, servicio) {
   if (btnTomarTurno) btnTomarTurno.disabled = true;
 
   await actualizarTurnoActualYConteo();
+}
+
+// ===== Lógica de Notificaciones =====
+async function solicitarPermisoNotificaciones() {
+  if (!('Notification' in window)) {
+    console.log("Este navegador no soporta notificaciones de escritorio");
+    return;
+  }
+  if (Notification.permission === 'granted') {
+    return;
+  }
+  if (Notification.permission !== 'denied') {
+    await Notification.requestPermission();
+  }
+}
+
+function enviarNotificacion(titulo, cuerpo) {
+  if ('Notification' in window && Notification.permission === 'granted') {
+    new Notification(titulo, { body: cuerpo });
+  }
 }
 
 // ===== Inicialización =====
@@ -603,6 +630,10 @@ window.addEventListener('DOMContentLoaded', async () => {
   const form = document.getElementById('formRegistroNegocio');
   const btnCerrarModal = document.getElementById('btn-cerrar-modal');
 
+  // Solicitar permiso de notificación al tomar turno
+  if (btnTomarTurno) {
+    btnTomarTurno.addEventListener('click', solicitarPermisoNotificaciones);
+  }
   // Event listener para cerrar el modal
   if (btnCerrarModal) {
     btnCerrarModal.addEventListener('click', cerrarModal);
@@ -706,30 +737,56 @@ supabase
 
 // ... existing code ...   telefonoUsuario = localStorage.getItem('telefonoUsuario');
         if (telefonoUsuario) {
-          const { data, error } = await supabase
+          const { data: miTurno, error: miTurnoError } = await supabase
             .from('turnos')
-            .select('*')
+            .select('turno, nombre, estado')
             .eq('negocio_id', negocioId)
             .eq('telefono', telefonoUsuario)
             .order('created_at', { ascending: false })
             .limit(1)
             .single();
 
-          if (!error && data && data.estado !== 'En espera') {
-            const cont = document.getElementById('mensaje-turno');
-            if (cont) {
-              cont.innerHTML = `
-                <div class="bg-blue-100 text-blue-700 rounded-xl p-4 shadow mt-4 text-sm">
-                  ✅ Tu turno <strong>${data.turno}</strong> ha sido ${data.estado.toLowerCase()}.
-                </div>
-              `;
+          if (miTurno) {
+            // Caso 1: El turno del usuario cambió a 'En atención'
+            if (miTurno.estado === 'En atención') {
+              enviarNotificacion(
+                `¡Es tu turno, ${miTurno.nombre}!`,
+                `Tu turno ${miTurno.turno} está siendo llamado ahora.`
+              );
+
+            // Caso 2: El turno del usuario ya no está activo (Atendido, Cancelado, etc.)
+            } else if (miTurno.estado !== 'En espera') {
+              const cont = document.getElementById('mensaje-turno');
+              if (cont) {
+                cont.innerHTML = `
+                  <div class="bg-blue-100 text-blue-700 rounded-xl p-4 shadow mt-4 text-sm">
+                    ✅ Tu turno <strong>${miTurno.turno}</strong> ha sido ${miTurno.estado.toLowerCase()}.
+                  </div>
+                `;
+              }
+              if (miTurno.estado === 'Atendido') {
+                enviarNotificacion('¡Gracias por tu visita!', `Tu turno ${miTurno.turno} ha finalizado.`);
+              }
+
+              // Limpiar estado del usuario
+              turnoAsignado = null;
+              if (btnTomarTurno) btnTomarTurno.disabled = false;
+              if (intervaloContador) clearInterval(intervaloContador);
+              localStorage.removeItem(getDeadlineKey(miTurno.turno));
+              localStorage.removeItem('telefonoUsuario');
+              telefonoUsuario = null;
+
+            // Caso 3: El turno sigue 'En espera', verificar posición en la cola
+            } else {
+              const posicion = await obtenerPosicionEnFila(miTurno.turno);
+              if (posicion === 1) {
+                enviarNotificacion('¡Ya casi es tu turno!', 'Solo queda 1 persona delante. ¡Puedes ir viniendo!');
+              } else if (posicion > 1) {
+                enviarNotificacion('La fila ha avanzado', `Ahora tienes ${posicion} personas delante.`);
+              } else if (posicion === 0) {
+                enviarNotificacion('¡Eres el siguiente!', 'Prepárate, te toca a ti después del turno actual.');
+              }
             }
-            turnoAsignado = null;
-            if (btnTomarTurno) btnTomarTurno.disabled = false;
-            if (intervaloContador) clearInterval(intervaloContador);
-            localStorage.removeItem(getDeadlineKey(data.turno));
-            localStorage.removeItem('telefonoUsuario');
-            telefonoUsuario = null;
           }
         }
         await actualizarTurnoActualYConteo();


### PR DESCRIPTION
### **User description**
…experiencia del usuario en la aplicación de turnos.

Las notificaciones se envían en los siguientes casos:
- Al tomar un turno, para confirmar la acción.
- Cuando la cola avanza, informando al usuario de su nueva posición.
- Cuando solo queda una persona por delante, para que el usuario se dirija al local.
- Cuando es el turno del usuario.

Se ha añadido la lógica para solicitar el permiso de notificaciones y para enviar las notificaciones en los momentos adecuados, utilizando el sistema de suscripciones en tiempo real de Supabase.


___

### **PR Type**
Enhancement


___

### **Description**
- Browser notification system for queue management

- Real-time notifications for queue position updates

- Permission handling and notification triggers

- Enhanced user experience with turn confirmations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User takes turn"] --> B["Request notification permission"]
  B --> C["Send confirmation notification"]
  D["Queue updates"] --> E["Check user position"]
  E --> F["Send position notifications"]
  F --> G["Notify when turn is ready"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>usuario.js</strong><dd><code>Browser notification system implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

usuario/usuario.js

<ul><li>Added notification permission request functionality<br> <li> Implemented notification sending for turn confirmations<br> <li> Enhanced real-time queue monitoring with position-based notifications<br> <li> Added notification triggers for turn status changes</ul>


</details>


  </td>
  <td><a href="https://github.com/Empredndedor/turnord-oficial/pull/24/files#diff-6e0f8fd3a60b9ee403de08a6a962129f7dabf540649279c3fdf50fb2528f71e4">+73/-16</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

